### PR TITLE
Add check to `run_me.bash` for `ckb-daemon`

### DIFF
--- a/src/run_me.bash
+++ b/src/run_me.bash
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if pgrep ckb-daemon > /dev/null; then
+  echo 'Please ensure ckb-daemon is not running before executing this script'
+  exit 1
+fi
+
 # Build the tools.
 gcc -o usbsh -Wall -O3 usbsh.c -lusb-1.0
 gcc -o sniff -Wall -O3 sniff.c -lusb-1.0


### PR DESCRIPTION
The `run_me.bash` script requires exclusive access to the USB hardware.

This adds a check to `run_me.bash` that will prevent the user from running the script while `ckb-daemon` running.